### PR TITLE
Fixed `lua` command

### DIFF
--- a/console.lua
+++ b/console.lua
@@ -474,7 +474,13 @@ console.defineCommand(
 	"lua",
 	"Lets you run lua code from the terminal",
 	function(args)
-		if type(args) == "string" then args = {args} end
+		if args == nil then
+			console.i("This command lets you run lua code from the terminal.")
+			console.i("It's a really dangerous command. Don't use it!")
+			return
+		elseif type(args) == "string" then 
+			args = {args}
+		end
 		for k,v in pairs(args) do
 			local ok,err = pcall(loadstring(v))
 			if ok then


### PR DESCRIPTION
Fixes issue #11 Passing a single argument to the `lua` command breaks with an error in `ipairs`. This is fixed by cheking if the element passed was a `string` (this is the case when there is a single argument) and putting it in a table before passing it to the `ipairs` function
