### PR TITLE
Improved lua command.

### DIFF
--- a/console.lua
+++ b/console.lua
@@ -460,24 +460,17 @@ console.defineCommand(
 console.defineCommand(
 	"lua",
 	"Lets you run lua code from the terminal",
-	function(args)
-		if args == nil then
+	function(...)
+		local cmd = ""
+		for i = 1, select("#", ...) do
+			cmd = cmd .. tostring(select(i, ...)) .. " "
+		end
+		if cmd == "" then
 			console.i("This command lets you run lua code from the terminal.")
 			console.i("It's a really dangerous command. Don't use it!")
 			return
-		elseif type(args) == "string" then 
-			args = {args}
 		end
-		for k,v in pairs(args) do
-			local ok,err = pcall(loadstring(v))
-			if ok then
-				if err then
-					console.d(err)
-				end
-			else
-				console.e(err)
-			end
-		end
+		xpcall(loadstring(cmd), console.e)
 	end,
 	true
 )


### PR DESCRIPTION
Changed to accept a vararg instead of just a string, switched to xpcall for cleanliness.
tested with:
```lua
lua console.d("foo"); lua console.e("bar")
lua c = console.e c("test")
```
...and a few other things. No problems with anything as long as it doesn't contain a semicolon. The string split in the input callback should be fixed at some point to ignore semicolons inside of quoted strings, but that's got nothing to do with the lua command itself.