### PR TITLE
Fix history skip issue

### DIFF
--- a/console.lua
+++ b/console.lua
@@ -242,7 +242,7 @@ function console.keypressed(key)
 		local valid = trimmed ~= ""
 		if valid then
 			table.insert(console.history, trimmed)
-			console.historyPosition = #console.history
+			console.historyPosition = #console.history + 1
 		end
 		console.input = ""
 		console.cursor = 0
@@ -277,9 +277,9 @@ function console.keypressed(key)
 				console.historyPosition = math.min(math.max(console.historyPosition - 1, 1), #console.history)
 				console.input = console.history[console.historyPosition]
 			elseif key == console._KEY_DOWN then
-				local pushing = console.historyPosition + 1 == #console.history + 1
-				console.historyPosition = math.min(console.historyPosition + 1, #console.history)
-				console.input = console.history[console.historyPosition]
+				local pushing = console.historyPosition + 1 > #console.history + 1
+				console.historyPosition = math.min(console.historyPosition + 1, #console.history + 1)
+				console.input = console.history[console.historyPosition] or ""
 				if pushing then
 					console.input = ""
 				end


### PR DESCRIPTION
Fixed Issue #21.  The history pointer should actually be *after* the list when typing a new line so that the first 'up' will move to the last actual history item in the list.  Likewise down can go past the end of the list and set the input to blank.